### PR TITLE
Add iOS bundle IDs (issue #117)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Main files:
 * `ioc.yaml` : Indicators of compromise of many Stalkerware apps. Includes
     * [Applications Package names](https://support.google.com/admob/answer/9972781)
     * [Android Application Certificates](https://support.google.com/googleplay/android-developer/answer/9842756?hl=en)
+    * [iOS Application bundle IDs](https://support.apple.com/guide/deployment/bundle-ids-for-native-iphone-and-ipad-apps-depece748c41/web)
     * List of websites
     * List of domains and IPs of [C2](https://en.wikipedia.org/wiki/Botnet#Command_and_control)
 * `watchware.yaml` : Indicators of compromise of watchware apps

--- a/scripts/generate.py
+++ b/scripts/generate.py
@@ -196,6 +196,11 @@ def generate_stix(folder, iocs, watchware):
             res.append(i)
             res.append(Relationship(i, 'indicates', malware))
 
+        for a in app.get("ios_bundles", []):
+            i = Indicator(indicator_types=["malicious-activity"], pattern="[app:id='{}']".format(a), pattern_type="stix")
+            res.append(i)
+            res.append(Relationship(i, 'indicates', malware))
+
         for c in app.get("certificates", []):
             i = Indicator(indicator_types=["malicious-activity"], pattern="[app:cert.sha1='{}']".format(c), pattern_type="stix")
             res.append(i)
@@ -225,6 +230,11 @@ def generate_stix(folder, iocs, watchware):
             res.append(Relationship(i, 'indicates', malware))
 
         for a in app.get("packages", []):
+            i = Indicator(indicator_types=["malicious-activity"], pattern="[app:id='{}']".format(a), pattern_type="stix")
+            res.append(i)
+            res.append(Relationship(i, 'indicates', malware))
+
+        for a in app.get("ios_bundles", []):
             i = Indicator(indicator_types=["malicious-activity"], pattern="[app:id='{}']".format(a), pattern_type="stix")
             res.append(i)
             res.append(Relationship(i, 'indicates', malware))

--- a/watchware.yaml
+++ b/watchware.yaml
@@ -79,6 +79,8 @@
   type: watchware
   packages:
   - org.findmykids.app
+  ios_bundles:
+  - com.wheremychildren.ios
   certificates:
   - 2A57777E3B9491A37392AFCE2E69D030DBF95037
   websites:
@@ -124,6 +126,8 @@
   type: watchware
   packages:
   - com.life360.android.safetymapd
+  ios_bundles:
+  - com.life360.safetymap
   certificates:
   - 19C0868F028757F49FD8F7BDF39FF70C771D622B
   websites:


### PR DESCRIPTION
Initial PR to add iOS bundle IDs

- [x] Include these records in the generated STIX2 files
- [x] Test that bundle IDs are checked by MVT
- [ ] Add additional known bundles for watchware and stalkerware apps.