### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ If you want to do further research on some apps and need access to the samples, 
 
 There are other repositories gathering stalkerware indicators:
 * [ch33r10 stalkerware list](https://github.com/ch33r10/Stalkerware/tree/master/IOCs)
-* [astryzia](https://github.com/astryzia/stalkerware-urls)
+* [astryzia](https://web.archive.org/web/20210628103647/https://github.com/astryzia/stalkerware-urls) (no longer exists)
 * [diskurse android stalkerware](https://github.com/diskurse/android-stalkerware)
 * [TinyCheck IOCs](https://github.com/KasperskyLab/TinyCheck/blob/main/assets/iocs.json)
 


### PR DESCRIPTION
`https://github.com/astryzia/stalkerware-urls` returns a 404, and while the repository is archived in the Wayback Machine, the list is not.
As such, I have updated the link to point to the Wayback Machine and noted that it does not exist.
Thanks.

P.S.
Thank you for your work