### PR TITLE
add new AhMyth package name IOC

### DIFF
--- a/ioc.yaml
+++ b/ioc.yaml
@@ -3610,6 +3610,7 @@
   type: stalkerware
   packages:
   - net.droid.talk218
+  - ahmyth.mine.king.ahmyth
   certificates:
   - 0ECD5FD80682776D804715AB5B8504DAF59A4B54
   c2:


### PR DESCRIPTION
This PR updates our IOC repository to include the latest Android package identifier used by the AhMyth RAT.

Change : 
Added ahmyth.mine.king.ahmyth to the list of Android package name IOCs.
